### PR TITLE
Final test fix

### DIFF
--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -83,31 +83,17 @@ def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
     else:
         x = Input(shape=input_shape[1:], dtype=input_dtype)
     y = layer(x)
-    if isinstance(y, list):
-        for tensor in y:
-            assert K.dtype(tensor) == expected_output_dtype
-    else:
-        assert K.dtype(y) == expected_output_dtype
+    assert K.dtype(y) == expected_output_dtype
 
     # check shape inference
     model = Model(x, y)
     expected_output_shape = layer.compute_output_shape(input_shape)
     actual_output = model.predict(input_data)
-    if isinstance(actual_output, list):
-        assert len(actual_output) == len(expected_output_shape)
-        for idx, partial_actual_output in enumerate(actual_output):
-            partial_actual_output_shape = partial_actual_output.shape
-            partial_expected_output_shape = expected_output_shape[idx]
-            for expected_dim, actual_dim in zip(partial_expected_output_shape,
-                                                partial_actual_output_shape):
-                if expected_dim is not None:
-                    assert expected_dim == actual_dim
-    else:
-        actual_output_shape = actual_output.shape
-        for expected_dim, actual_dim in zip(expected_output_shape,
-                                            actual_output_shape):
-            if expected_dim is not None:
-                assert expected_dim == actual_dim
+    actual_output_shape = actual_output.shape
+    for expected_dim, actual_dim in zip(expected_output_shape,
+                                        actual_output_shape):
+        if expected_dim is not None:
+            assert expected_dim == actual_dim
     if expected_output is not None:
         assert_allclose(actual_output, expected_output, rtol=1e-3)
 


### PR DESCRIPTION
Replaced the other PR with this one that also passes every test.

I did the changes manually instead of reverting because it was faster this way, but the end result should be the same. With a squash/rebase we should end up with a PR that only has a couple changes in `keras/layers/core.py` and `tests/keras/layers/core_test.py`.